### PR TITLE
Add Save/Load State to All.cfg

### DIFF
--- a/pspi/buttons/all.cfg
+++ b/pspi/buttons/all.cfg
@@ -549,9 +549,9 @@ menu_swap_ok_cancel_buttons = "false"
 # input_toggle_fullscreen = f
 
 # Saves state.
-# input_save_state = f2
+input_save_state = "ralt"
 # Loads state.
-# input_load_state = f4
+input_load_state = "alt"
 
 # State slots. With slot set to 0, save state name is *.state (or whatever defined on commandline).
 # When slot is != 0, path will be $path%d, where %d is slot number.

--- a/pspi/buttons/retrogame.cfg
+++ b/pspi/buttons/retrogame.cfg
@@ -27,7 +27,7 @@ LEFT       44  # B3 Left
 LEFTALT    43  # B4 Left Trigger
 KPMINUS    42  # B5 +
 KPPLUS     41  # B6 -
-S     	   40  # B7 Mute
+D     	   40  # B7 Mute
 
 
 

--- a/pspi/buttons/retrogame.cfg
+++ b/pspi/buttons/retrogame.cfg
@@ -27,7 +27,7 @@ LEFT       44  # B3 Left
 LEFTALT    43  # B4 Left Trigger
 KPMINUS    42  # B5 +
 KPPLUS     41  # B6 -
-#MUTE	   40  # B7 Mute
+S     	   40  # B7 Mute
 
 
 

--- a/pspi/buttons/retrogame.cfg
+++ b/pspi/buttons/retrogame.cfg
@@ -27,7 +27,7 @@ LEFT       44  # B3 Left
 LEFTALT    43  # B4 Left Trigger
 KPMINUS    42  # B5 +
 KPPLUS     41  # B6 -
-#MUTE  	   40  # B7 Mute
+#MUTE      40  # B7 Mute
 
 
 

--- a/pspi/buttons/retrogame.cfg
+++ b/pspi/buttons/retrogame.cfg
@@ -27,7 +27,7 @@ LEFT       44  # B3 Left
 LEFTALT    43  # B4 Left Trigger
 KPMINUS    42  # B5 +
 KPPLUS     41  # B6 -
-D     	   40  # B7 Mute
+#MUTE  	   40  # B7 Mute
 
 
 


### PR DESCRIPTION
Forgot to add Save/Load State to All.cfg and changed retrogame.cfg so that Mute passes the same value as Select. This allows you to use either Mute or Select as the hotkey and maintains Home as the shortcut for exiting games.